### PR TITLE
Update AdminApi.php

### DIFF
--- a/src/Admin/AdminApi.php
+++ b/src/Admin/AdminApi.php
@@ -376,7 +376,7 @@ class AdminApi extends AbstractApi implements AdminApiInterface
      * {@inheritdoc}
      */
     public function checkDomainMXRecord(
-        DomainSelector $domain = null
+        ?DomainSelector $domain = null
     ): ?Message\CheckDomainMXRecordResponse {
         return $this->invoke(new Message\CheckDomainMXRecordRequest($domain));
     }


### PR DESCRIPTION
 PHP Deprecated:  Zimbra\Admin\AdminApi::checkDomainMXRecord(): Implicitly marking parameter $domain as nullable is deprecated