### PR TITLE
Allow usage for psr\log v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr-discovery/http-factory-implementations": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/log": "^3.0"
+        "psr/log": "^2.0|^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.0",


### PR DESCRIPTION
Version v3 of PSR Logger only introduce stricter return types, that are not relevant for this project.

However, not supporting version v2 creates an hard block for Symfony 5.4 LTS applications, that are still supported and that are subject to progressive upgrade for upcoming version.

I'm currently in the process of upgrading the codebase from PHP7+Symfony 5.4 to PHP8+Symfony 6.4, and this limitation prevent me to implement a step by step refactoring. 

I see no drawback in this project for supporting v2 too. Note also that major soap-api v1 only support psr/log v1, while soap-api v2/v3 only support v3