### PR TITLE
fix: Make Cookie header RFC-Compliant

### DIFF
--- a/src/Common/Soap/Client.php
+++ b/src/Common/Soap/Client.php
@@ -129,7 +129,7 @@ class Client implements ClientInterface
         );
         if ($this->httpResponse->hasHeader("Set-Cookie")) {
             $this->cookie = implode(
-                ';',
+                '; ',
                 array_map(fn($str) => trim(explode(';', $str)[0]), $this->httpResponse->getHeader("Set-Cookie"))
             );
         }

--- a/src/Common/Soap/Client.php
+++ b/src/Common/Soap/Client.php
@@ -129,8 +129,8 @@ class Client implements ClientInterface
         );
         if ($this->httpResponse->hasHeader("Set-Cookie")) {
             $this->cookie = implode(
-                ", ",
-                $this->httpResponse->getHeader("Set-Cookie")
+                ';',
+                array_map(fn($str) => trim(explode(';', $str)[0]), $this->httpResponse->getHeader("Set-Cookie"))
             );
         }
         return $this->httpResponse;


### PR DESCRIPTION
Attributes from Set-Cookie were included in the Cookie header ie:
Cookie: ZM_ADMIN_AUTH_TOKEN=0_....; Path=/;SameSite=None;; Secure; HttpOnly, TS...=....; Path=/; Domain=.domain.com
With the change the header only contains cookie name-value pairs separated by a semicolumn followaed by a space, as specified by RFC 6265 (https://www.rfc-editor.org/rfc/rfc6265#section-4.2.1), ie:
Cookie: ZM_ADMIN_AUTH_TOKEN=0_....;TS...=....